### PR TITLE
Load subcommand plug-ins at runtime

### DIFF
--- a/lib/claide/command.rb
+++ b/lib/claide/command.rb
@@ -201,6 +201,7 @@ module CLAide
       # @return [void]
       #
       def run(argv)
+        load_plugins
         command = parse(argv)
         command.validate!
         command.run
@@ -261,6 +262,39 @@ module CLAide
         Banner.new(self, colorize).formatted_banner
       end
 
+      # Load additional plugins via rubygems looking for:
+      #
+      # <command-path>/plugin.rb
+      #
+      # where <command-path> is the namespace of the Command converted to a
+      # path, for example:
+      #
+      # Pod::Command
+      #
+      # maps to
+      #
+      # pod/command
+      #
+      def load_plugins
+        if Gem.respond_to? :find_latest_files
+          Gem.find_latest_files("#{underscore(name)}/plugin").each {|path| require path }
+        else
+          Gem.find_files("#{underscore(name)}/plugin").each {|path| require path }
+        end
+      end
+
+      private
+
+      # Cribbed from ActiveSupport
+      # https://github.com/rails/rails/blob/master/activesupport/MIT-LICENSE
+      def underscore(str)
+        underscored = str.to_s.dup
+        underscored.gsub!(/::/, '/')
+        underscored.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+        underscored.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+        underscored.tr!("-", "_")
+        underscored.downcase!
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/fixture/command/demo_plugin.rb
+++ b/spec/fixture/command/demo_plugin.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+module Fixture
+  class Command
+    class DemoPlugin < Command
+      self.summary = 'Plugins!'
+      self.description = <<-DESC
+        Let’s add plugins to CLAide and CocoaPods.
+      DESC
+      self.arguments = '[NAME]'
+
+      attr_reader :name
+      def initialize(argv)
+        @name = argv.shift_argument
+        super
+      end
+    end
+  end
+end

--- a/spec/fixture/command/plugin_fixture.rb
+++ b/spec/fixture/command/plugin_fixture.rb
@@ -1,0 +1,3 @@
+# Load a CLAide plugin by requiring it in your `plugin.rb` or by
+# defining it directly in the file.
+require 'fixture/command/demo_plugin'


### PR DESCRIPTION
We use rubygems to load a subcommand plug-in gem with a file that can be loaded at

```
<command-path>/plugin.rb
```

The `command-path` is the namespace of the command converted to a path. For example `Pod::Command` becomes `pod/command`.

The `plugin.rb` file should either define the subcommand(s) directly or require the files for the subcommand(s). For example, the first working plugin, [open_pod_bay](https://github.com/leshill/open_pod_bay), provides an `open` subcommand and has the following `plugin.rb`

```
require 'pod/command/open'
```

`gem install open_pod_bay` to try it with this PR.
