### PR TITLE
Subcommand plugins via `cocoapods_plugin.rb` file

### DIFF
--- a/lib/claide/command.rb
+++ b/lib/claide/command.rb
@@ -69,6 +69,12 @@ module CLAide
       #
       attr_accessor :description
 
+      # @return [String] The prefix for loading CLAide plugins for this
+      #         command. Plugins are loaded via their
+      #         <plugin_prefix>_plugin.rb file.
+      #
+      attr_accessor :plugin_prefix
+
       # @return [String] A list of arguments the command handles. This is shown
       #         in the usage section of the command’s help banner.
       #
@@ -276,24 +282,12 @@ module CLAide
       # pod/command
       #
       def load_plugins
+        return unless plugin_prefix
         if Gem.respond_to? :find_latest_files
-          Gem.find_latest_files("#{underscore(name)}/plugin").each {|path| require path }
+          Gem.find_latest_files("#{plugin_prefix}_plugin").each {|path| require path }
         else
-          Gem.find_files("#{underscore(name)}/plugin").each {|path| require path }
+          Gem.find_files("#{plugin_prefix}_plugin").each {|path| require path }
         end
-      end
-
-      private
-
-      # Cribbed from ActiveSupport
-      # https://github.com/rails/rails/blob/master/activesupport/MIT-LICENSE
-      def underscore(str)
-        underscored = str.to_s.dup
-        underscored.gsub!(/::/, '/')
-        underscored.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
-        underscored.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
-        underscored.tr!("-", "_")
-        underscored.downcase!
       end
     end
 

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -18,9 +18,9 @@ module CLAide
       end
 
       describe "plugins" do
-        describe "when the plugin is at <command-path>/plugin.rb" do
+        describe "when the plugin is at <command-prefix>_plugin.rb" do
           PLUGIN_FIXTURE = Pathname.new(ROOT) + 'spec/fixture/command/plugin_fixture.rb'
-          PLUGIN = Pathname.new(ROOT) + 'spec/fixture/command/plugin.rb'
+          PLUGIN = Pathname.new(ROOT) + 'spec/fixture_plugin.rb'
 
           before do
             FileUtils.copy PLUGIN_FIXTURE, PLUGIN

--- a/spec/spec_helper/fixtures.rb
+++ b/spec/spec_helper/fixtures.rb
@@ -4,6 +4,7 @@ module Fixture
   end
 
   class Command < CLAide::Command
+    self.plugin_prefix = 'fixture'
     self.command = 'bin'
 
     class SpecFile < Command


### PR DESCRIPTION
Any CLAide Command can load subcommand plugins by setting the Command.plugin_prefix for the
command. Installed gems with a file named `<plugin_prefix>_plugin.rb` will be loaded
via that file. Convention is to require the actual command implementation in
the plugin file.

If Command.plugin_prefix is not set, no attempt is made to load any plugins.

PR https://github.com/CocoaPods/CocoaPods/pull/1563 on CocoaPods to set the `Command#plugin_prefix`.

The `open` command has been updated here https://github.com/leshill/open_pod_bay/tree/new_style
