### PR TITLE
silence error while loading cocoapods plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CLAide Changelog
 
+## 0.9.0
+
+###### Enhancements
+
+* Silence error while loading cocoapods plugins [Clément Beffa](https://github.com/cl3m)
+  [#44](https://github.com/CocoaPods/CLAide/issues/44)
+
 ## 0.8.0
 
 ###### Breaking

--- a/lib/claide/command/plugin_manager.rb
+++ b/lib/claide/command/plugin_manager.rb
@@ -54,7 +54,9 @@ module CLAide
       #
       def self.specification(path)
         matches = Dir.glob("#{path}/*.gemspec")
-        spec = silence_streams(STDERR) { Gem::Specification.load(matches.first)} if matches.count == 1 
+          spec = silence_streams(STDERR) {
+            Gem::Specification.load(matches.first)
+          } if matches.count == 1
         unless spec
           warn '[!] Unable to load a specification for the plugin ' \
             "`#{path}`".ansi.yellow
@@ -113,13 +115,12 @@ module CLAide
         false
       end
       # rubocop:enable RescueException
-      
-      
+
       # Execute block while silence stream
       #
       # credit to DHH http://stackoverflow.com/a/8959520
       def self.silence_streams(*streams)
-        on_hold = streams.collect { |stream| stream.dup }
+        on_hold = streams.collect(&:dup)
         streams.each do |stream|
           stream.reopen('/dev/null')
           stream.sync = true

--- a/lib/claide/command/plugin_manager.rb
+++ b/lib/claide/command/plugin_manager.rb
@@ -54,9 +54,9 @@ module CLAide
       #
       def self.specification(path)
         matches = Dir.glob("#{path}/*.gemspec")
-          spec = silence_streams(STDERR) {
-            Gem::Specification.load(matches.first)
-          } if matches.count == 1
+        spec = silence_streams(STDERR) do
+          Gem::Specification.load(matches.first)
+        end if matches.count == 1
         unless spec
           warn '[!] Unable to load a specification for the plugin ' \
             "`#{path}`".ansi.yellow

--- a/lib/claide/command/plugin_manager.rb
+++ b/lib/claide/command/plugin_manager.rb
@@ -121,7 +121,7 @@ module CLAide
       def self.silence_streams(*streams)
         on_hold = streams.collect { |stream| stream.dup }
         streams.each do |stream|
-          stream.reopen(RUBY_PLATFORM =~ /mswin/ ? 'NUL:' : '/dev/null')
+          stream.reopen('/dev/null')
           stream.sync = true
         end
         yield

--- a/lib/claide/command/plugin_manager.rb
+++ b/lib/claide/command/plugin_manager.rb
@@ -120,7 +120,7 @@ module CLAide
       #
       # credit to DHH http://stackoverflow.com/a/8959520
       def self.silence_streams(*streams)
-        on_hold = streams.collect(&:dup)
+        on_hold = streams.map(&:dup)
         streams.each do |stream|
           stream.reopen('/dev/null')
           stream.sync = true


### PR DESCRIPTION
When doing a "pod install" on a directory not under git, there are error for each plugins : 
"fatal: Not a git repository (or any of the parent directories): .git"
Because the cocoapods plugin gemspec list files using "git ls-files" .. the plugin gem will not be under git anymore so it will always produce an error, thus this code silence it

