### PR TITLE
[PluginManager] Silence loading of Gem specs.

### DIFF
--- a/lib/claide/command/plugin_manager.rb
+++ b/lib/claide/command/plugin_manager.rb
@@ -54,7 +54,10 @@ module CLAide
       #
       def self.specification(path)
         matches = Dir.glob("#{path}/*.gemspec")
-        spec = Gem::Specification.load(matches.first) if matches.count == 1
+        spec = nil
+        silence_stderr do
+          spec = Gem::Specification.load(matches.first) if matches.count == 1
+        end
         unless spec
           warn '[!] Unable to load a specification for the plugin ' \
             "`#{path}`".ansi.yellow
@@ -113,6 +116,19 @@ module CLAide
         false
       end
       # rubocop:enable RescueException
+
+      private
+
+      def self.silence_stderr
+        begin
+          orig_stderr = $stderr.clone
+          $stderr.reopen File.new('/dev/null', 'w')
+          retval = yield
+        ensure
+          $stderr.reopen orig_stderr
+        end
+        retval
+      end
     end
   end
 end


### PR DESCRIPTION
Any plugin gemspecs which use `git ls-files` polute the output with fatal Git errors otherwise. This can be the case when one uses bundler local dependencies or when installing plugins manually from a Git repo.

Before this:

```
$ pod install --no-integrate
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
Analyzing dependencies
[...]
```