### PR TITLE
Add alias commands macro

### DIFF
--- a/lib/claide/command.rb
+++ b/lib/claide/command.rb
@@ -143,6 +143,10 @@ module CLAide
       end
       attr_writer :command
 
+      # @return [Array<String>] Aliases for the command.
+      #
+      attr_accessor :alias_commands
+
       # @return [String] The version of the command. This value will be printed
       #         by the `--version` flag if used for the root command.
       #
@@ -208,7 +212,16 @@ module CLAide
     # @return [CLAide::Command, nil] The subcommand, if found.
     #
     def self.find_subcommand(name)
-      subcommands_for_command_lookup.find { |sc| sc.command == name }
+      command = subcommands_for_command_lookup.find { |sc| sc.command == name }
+
+      unless command
+        command = subcommands_for_command_lookup.find do |sc|
+          next unless sc.alias_commands
+          sc.alias_commands.find { |ac| ac == name }
+        end
+      end
+
+      command
     end
 
     # @visibility private

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -25,6 +25,11 @@ module CLAide
         subcommands.map(&:command).should == %w(lint create)
       end
 
+      it 'returns subcommand for look up and includes alias commands' do
+        subcommands = @command::SpecFile.subcommands_for_command_lookup
+        subcommands.map(&:alias_commands).should == [%w(l), %w(c)]
+      end
+
       it 'returns whether it is the root command' do
         @command.should.be.root_command?
         @command::SpecFile.should.not.be.root_command?

--- a/spec/spec_helper/fixtures.rb
+++ b/spec/spec_helper/fixtures.rb
@@ -31,6 +31,7 @@ module Fixture
         self.arguments = [
           CLAide::Argument.new('NAME', false),
         ]
+        self.alias_commands = ['l']
 
         def self.options
           [['--only-errors', 'Skip warnings']].concat(super)
@@ -50,6 +51,7 @@ module Fixture
         self.arguments = [
           CLAide::Argument.new('NAME', false),
         ]
+        self.alias_commands = ['c']
 
         attr_reader :spec
         def initialize(argv)


### PR DESCRIPTION
This would useful if you wanted to run `hello g ...` instead of `hello
generate ...`

\c @segiddins 
