### PR TITLE
Fix circular require considered harmful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Fix circular require of `claide/ansi` in `claide/ansi/string_escaper`.  
+  [bootstraponline](https://github.com/bootstraponline)
+  [#66](https://github.com/CocoaPods/CLAide/issues/66)  
 
 
 ## 1.0.0.beta.3 (2016-03-15)

--- a/lib/claide/ansi/string_escaper.rb
+++ b/lib/claide/ansi/string_escaper.rb
@@ -1,5 +1,3 @@
-require 'claide/ansi'
-
 module CLAide
   class ANSI
     # Provides support to wrap strings in ANSI sequences according to the


### PR DESCRIPTION
Fix #66

`claide/ansi` requires `claide/ansi/string_escaper` which requires `claide/ansi`