### PR TITLE
Fix plugin_manager exception when syntax error is thrown

### DIFF
--- a/lib/claide/command/plugin_manager.rb
+++ b/lib/claide/command/plugin_manager.rb
@@ -98,7 +98,11 @@ module CLAide
         message = "\n---------------------------------------------"
         message << "\nError loading the plugin `#{spec.full_name}`.\n"
         message << "\n#{exception.class} - #{exception.message}"
-        message << "\n#{exception.backtrace.join("\n")}"
+        if exception.backtrace
+          # An exception might have no stack trace, for example when
+          # one of the plugins has a syntax error
+          message << "\n#{exception.backtrace.join("\n")}"
+        end
         message << "\n---------------------------------------------\n"
         warn message.ansi.yellow
         false


### PR DESCRIPTION
Fix a crash when the exception doesn't contain a `backtrace`
```
exception => #<SyntaxError: .../plugin.rb:127: syntax error, unexpected keyword_end, expecting end-of-input>
exception.backtrace => nil
```