### PR TITLE
[InformativeError] Avoid redefining #exit_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ##### Bug Fixes
 
-* None.  
+* Avoid a method redefinition warning when requiring `claide`.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 
 ## 1.0.1 (2016-10-10)

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 group :spec do
   gem 'bacon'
-  gem 'json'
+  gem 'json', '< 2'
   gem 'mocha-on-bacon'
   gem 'prettybacon'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     colored (1.2)
     docile (1.1.5)
     ffi (1.9.6)
-    json (1.8.3)
+    json (1.8.6)
     kicker (3.0.0)
       listen (~> 1.3.0)
       notify (~> 0.5.2)
@@ -62,7 +62,7 @@ DEPENDENCIES
   claide!
   codeclimate-test-reporter
   colored
-  json
+  json (< 2)
   kicker
   mocha-on-bacon
   prettybacon
@@ -71,4 +71,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/lib/claide/informative_error.rb
+++ b/lib/claide/informative_error.rb
@@ -12,7 +12,7 @@ module CLAide
     # @return [Numeric] The exist status code that should be used to terminate
     #         the program with. Defaults to `1`.
     #
-    attr_accessor :exit_status
+    attr_writer :exit_status
 
     def exit_status
       @exit_status ||= 1


### PR DESCRIPTION
This avoids a warning.