### PR TITLE
Spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,24 +28,24 @@ by the user.
 Working with parameters is done through the `CLAide::ARGV` class. It takes an
 array of parameters and parses them as either flags, options, or arguments.
 
-| Parameter             | Description                                       |
-| :---:                 | :---:                                             |
-| `--milk`, `--no-milk` | A boolean ‘flag’, which may be negated.           |
-| `--sweetner=honey`    | A ‘option’ consists of a key, a ‘=’, and a value. |
-| `tea`                 | A ‘argument’ is just a value.                     |
+| Parameter              | Description                                        |
+| :---:                  | :---:                                              |
+| `--milk`, `--no-milk`  | A boolean ‘flag’, which may be negated.            |
+| `--sweetener=honey`    | An ‘option’ consists of a key, a ‘=’, and a value. |
+| `tea`                  | An ‘argument’ is just a value.                     |
 
 
 Accessing flags, options, and arguments, with the following methods, will also
 remove the parameter from the remaining unprocessed parameters.
 
 ```ruby
-argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetner=honey'])
+argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetener=honey'])
 argv.shift_argument     # => 'tea'
 argv.shift_argument     # => nil
 argv.flag?('milk')      # => false
 argv.flag?('milk')      # => nil
-argv.option('sweetner') # => 'honey'
-argv.option('sweetner') # => nil
+argv.option('sweetener') # => 'honey'
+argv.option('sweetener') # => nil
 ```
 
 
@@ -55,7 +55,7 @@ specify a default value to be used as the optional second method parameter:
 ```ruby
 argv = CLAide::ARGV.new(['tea'])
 argv.flag?('milk', true)         # => true
-argv.option('sweetner', 'sugar') # => 'sugar'
+argv.option('sweetener', 'sugar') # => 'sugar'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ remove the parameter from the remaining unprocessed parameters.
 
 ```ruby
 argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetener=honey'])
-argv.shift_argument     # => 'tea'
-argv.shift_argument     # => nil
-argv.flag?('milk')      # => false
-argv.flag?('milk')      # => nil
+argv.shift_argument      # => 'tea'
+argv.shift_argument      # => nil
+argv.flag?('milk')       # => false
+argv.flag?('milk')       # => nil
 argv.option('sweetener') # => 'honey'
 argv.option('sweetener') # => nil
 ```

--- a/examples/argv.rb
+++ b/examples/argv.rb
@@ -5,10 +5,10 @@ $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'claide'
 
 argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetener=honey'])
-p argv.shift_argument     # => 'tea'
-p argv.shift_argument     # => nil
-p argv.flag?('milk')      # => false
-p argv.flag?('milk')      # => nil
+p argv.shift_argument      # => 'tea'
+p argv.shift_argument      # => nil
+p argv.flag?('milk')       # => false
+p argv.flag?('milk')       # => nil
 p argv.option('sweetener') # => 'honey'
 p argv.option('sweetener') # => nil
 
@@ -22,5 +22,5 @@ p argv.arguments  # => []
 puts
 
 argv = CLAide::ARGV.new(['tea'])
-p argv.flag?('milk', true)         # => true
+p argv.flag?('milk', true)          # => true
 p argv.option('sweetener', 'sugar') # => 'sugar'

--- a/examples/argv.rb
+++ b/examples/argv.rb
@@ -4,13 +4,13 @@ $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 
 require 'claide'
 
-argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetner=honey'])
+argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetener=honey'])
 p argv.shift_argument     # => 'tea'
 p argv.shift_argument     # => nil
 p argv.flag?('milk')      # => false
 p argv.flag?('milk')      # => nil
-p argv.option('sweetner') # => 'honey'
-p argv.option('sweetner') # => nil
+p argv.option('sweetener') # => 'honey'
+p argv.option('sweetener') # => nil
 
 puts
 
@@ -23,4 +23,4 @@ puts
 
 argv = CLAide::ARGV.new(['tea'])
 p argv.flag?('milk', true)         # => true
-p argv.option('sweetner', 'sugar') # => 'sugar'
+p argv.option('sweetener', 'sugar') # => 'sugar'

--- a/examples/make.rb
+++ b/examples/make.rb
@@ -20,20 +20,20 @@ class BeverageMaker < CLAide::Command
   def self.options
     [
       ['--no-milk', 'Don’t add milk to the beverage'],
-      ['--sweetner=[sugar|honey]', 'Use one of the available sweetners'],
+      ['--sweetener=[sugar|honey]', 'Use one of the available sweeteners'],
     ].concat(super)
   end
 
   def initialize(argv)
     @add_milk = argv.flag?('milk', true)
-    @sweetner = argv.option('sweetner')
+    @sweetener = argv.option('sweetener')
     super
   end
 
   def validate!
     super
-    if @sweetner && !%w(sugar honey).include?(@sweetner)
-      help! "`#{@sweetner}' is not a valid sweetner."
+    if @sweetener && !%w(sugar honey).include?(@sweetener)
+      help! "`#{@sweetener}' is not a valid sweetener."
     end
   end
 
@@ -44,8 +44,8 @@ class BeverageMaker < CLAide::Command
       puts '* Adding milk…'
       sleep 1
     end
-    if @sweetner
-      puts "* Adding #{@sweetner}…"
+    if @sweetener
+      puts "* Adding #{@sweetener}…"
       sleep 1
     end
   end

--- a/lib/claide/argv.rb
+++ b/lib/claide/argv.rb
@@ -38,9 +38,9 @@ module CLAide
     #
     # @example
     #
-    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetner=honey'])
+    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetener=honey'])
     #   argv.shift_argument # => 'tea'
-    #   argv.remainder      # => ['--no-milk', '--sweetner=honey']
+    #   argv.remainder      # => ['--no-milk', '--sweetener=honey']
     #
     def remainder
       @entries.map do |type, (key, value)|
@@ -60,9 +60,9 @@ module CLAide
     #
     # @example
     #
-    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetner=honey'])
+    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetener=honey'])
     #   argv.shift_argument # => 'tea'
-    #   argv.remainder!     # => ['--no-milk', '--sweetner=honey']
+    #   argv.remainder!     # => ['--no-milk', '--sweetener=honey']
     #   argv.remainder      # => []
     #
     def remainder!
@@ -74,8 +74,8 @@ module CLAide
     #
     # @example
     #
-    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetner=honey'])
-    #   argv.options # => { 'milk' => false, 'sweetner' => 'honey' }
+    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetener=honey'])
+    #   argv.options # => { 'milk' => false, 'sweetener' => 'honey' }
     #
     def options
       options = {}
@@ -149,11 +149,11 @@ module CLAide
     #
     # @example
     #
-    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetner=honey'])
+    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetener=honey'])
     #   argv.flag?('milk')       # => false
     #   argv.flag?('milk')       # => nil
     #   argv.flag?('milk', true) # => true
-    #   argv.remainder           # => ['tea', '--sweetner=honey']
+    #   argv.remainder           # => ['tea', '--sweetener=honey']
     #
     def flag?(name, default = nil)
       delete_entry(:flag, name, default, true)
@@ -174,10 +174,10 @@ module CLAide
     #
     # @example
     #
-    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetner=honey'])
-    #   argv.option('sweetner')          # => 'honey'
-    #   argv.option('sweetner')          # => nil
-    #   argv.option('sweetner', 'sugar') # => 'sugar'
+    #   argv = CLAide::ARGV.new(['tea', '--no-milk', '--sweetener=honey'])
+    #   argv.option('sweetener')          # => 'honey'
+    #   argv.option('sweetener')          # => nil
+    #   argv.option('sweetener', 'sugar') # => 'sugar'
     #   argv.remainder                   # => ['tea', '--no-milk']
     #
     def option(name, default = nil)
@@ -251,10 +251,10 @@ module CLAide
       #
       # @example
       #
-      #   list = parse(['tea', '--no-milk', '--sweetner=honey'])
+      #   list = parse(['tea', '--no-milk', '--sweetener=honey'])
       #   list # => [[:arg, "tea"],
       #              [:flag, ["milk", false]],
-      #              [:option, ["sweetner", "honey"]]]
+      #              [:option, ["sweetener", "honey"]]]
       #
       def self.parse(argv)
         entries = []


### PR DESCRIPTION
Also renamed the README extension to `md`, and fixed some "a"s that should be "an"s.