### PR TITLE
CI: Update patch Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ rvm:
   - 2.0.0-p648
   - 2.1.10
   - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
 bundler_args: --without development
 before_install: 
   - if [ "$TRAVIS_RUBY_VERSION" == "1.8.7" ]; then gem update --system; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ rvm:
   - 2.6.1
 bundler_args: --without development
 before_install: 
-  - if [ "$TRAVIS_RUBY_VERSION" == "1.8.7" ]; then gem update --system; fi
+  - if [ "$TRAVIS_RUBY_VERSION" == "1.8.7" ]; then gem update --system -v'< 3'; fi
 script: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,4 @@ rvm:
 bundler_args: --without development
 before_install: 
   - if [ "$TRAVIS_RUBY_VERSION" == "1.8.7" ]; then gem update --system; fi
-  - gem install bundler
 script: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ rvm:
   - 2.6.1
 bundler_args: --without development
 before_install: 
-  - if [ "$TRAVIS_RUBY_VERSION" == "1.8.7" ]; then gem update --system -v'< 3'; fi
+  - if [ "$TRAVIS_RUBY_VERSION" == "1.8.7" ]; then gem update --system 2.7.9; fi
 script: bundle exec rake spec


### PR DESCRIPTION
This PR updates the CI matrix and fixes the build.

In order to support the full matrix:

- choose a specific RubyGems for Ruby 1.8.7
- let `rvm` supply a Bundler with each of the Rubies