### PR TITLE
Correctly handle `--help` flags when `argv.remainder!` is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+
+dist: trusty
+
 addons:
  code_climate:
    repo_token: 46c8b29dd6711f35704e7c5a541486cbbf2cff8b2df8ce755bfc09917d3c1cbb
@@ -7,11 +10,18 @@ branches:
     - master
     - /.+-stable$/
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.1.1
+  - 2.0.0-p647
+  - 2.1.10
+  - 2.2.9
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.2
 bundler_args: --without development
-before_install: 
-  - if [ "$TRAVIS_RUBY_VERSION" == "1.8.7" ]; then gem update --system; fi
-  - gem install bundler
+before_install:
+  # There is a bug in travis. When using system ruby, bundler is not
+  # installed and causes the default install action to fail.
+  - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.15.0"; else gem install "bundler:~> 1.15.0"; fi
+  # RubyGems 2.0.14 isn't a fun time on 2.0.0p648
+  - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem update --system; fi
 script: bundle exec rake spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Correctly handle `--help` flags when using `argv.remainder!` after initialization  
   [Eric Amorde](https://github.com/amorde),
   [tripleCC](https://github.com/tripleCC)
+  [#87](https://github.com/CocoaPods/CLAide/pull/87)
 
 
 ## 1.0.2 (2017-06-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Correctly handle `--help` flags when using `argv.remainder!` after initialization  
+  [Eric Amorde](https://github.com/amorde),
+  [tripleCC](https://github.com/tripleCC)
 
 
 ## 1.0.2 (2017-06-06)

--- a/lib/claide/command.rb
+++ b/lib/claide/command.rb
@@ -497,6 +497,15 @@ module CLAide
     attr_accessor :ansi_output
     alias_method :ansi_output?, :ansi_output
 
+    # Set to `true` if initialized with a `--help` flag
+    #
+    # @return [Boolean]
+    #
+    #   Whether the command was initialized with argv containing --help
+    #
+    attr_accessor :help_arg
+    alias_method :help?, :help_arg
+
     # Subclasses should override this method to remove the arguments/options
     # they support from `argv` _before_ calling `super`.
     #
@@ -514,6 +523,7 @@ module CLAide
       @verbose = argv.flag?('verbose')
       @ansi_output = argv.flag?('ansi', Command.ansi_output?)
       @argv = argv
+      @help_arg = argv.flag?('help')
     end
 
     # Convenience method.
@@ -553,7 +563,7 @@ module CLAide
     # @return [void]
     #
     def validate!
-      banner! if @argv.flag?('help')
+      banner! if help?
       unless @argv.empty?
         argument = @argv.remainder.first
         help! ArgumentSuggester.new(argument, self.class).suggestion

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -304,6 +304,15 @@ module CLAide
         cmd.class.expects(:help!)
         cmd.send(:help!)
       end
+
+      it 'remembers if --help was specified' do
+        args = ARGV.coerce(%w(create --help))
+        cmd = @command_class.new(args)
+        args.remainder!
+        cmd.expects(:banner!).once
+        cmd.stubs(:help!)
+        cmd.send(:validate!)
+      end
     end
   end
 


### PR DESCRIPTION
Supersedes https://github.com/CocoaPods/CocoaPods/pull/8571